### PR TITLE
AAVEv3 Plus discretional vault Asset Manager

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,8 @@
+module.exports = {
+  //   workingDir: process.cwd(),
+  //   contractsDir: path.join(process.cwd(), "contracts"),
+  //   instrumentedDir: path.join(process.cwd(), "instrumented"),
+  //   client: client,
+  skipFiles: ["dependencies/", "mocks/"],
+  //   logger: console,
+};

--- a/contracts/AAVEv2AssetManager.sol
+++ b/contracts/AAVEv2AssetManager.sol
@@ -40,7 +40,9 @@ contract AAVEv2AssetManager is LiquidityThresholdAssetManager {
 
   function deinvestAll() external override returns (int256 earnings) {
     DiamondStorage storage ds = diamondStorage();
-    uint256 withdrawn = _aave.withdraw(address(_asset), type(uint256).max, address(this));
+    uint256 withdrawn = (_aToken.balanceOf(address(this)) != 0)
+      ? _aave.withdraw(address(_asset), type(uint256).max, address(this))
+      : 0;
     earnings = int256(withdrawn) - int256(uint256(ds.lastInvestmentValue));
     ds.lastInvestmentValue = 0;
     emit MoneyDeinvested(withdrawn);

--- a/contracts/AAVEv3AssetManager.sol
+++ b/contracts/AAVEv3AssetManager.sol
@@ -6,7 +6,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 import {IPool} from "./dependencies/aave-v3/IPool.sol";
 
 /**
- * @title Asset Manager that deploys the funds into an ERC4626 vault
+ * @title Asset Manager that deploys the funds into AAVEv3
  * @dev Using liquidity thresholds defined in {LiquidityThresholdAssetManager}, deploys the funds into AAVEv3.
  * @custom:security-contact security@ensuro.co
  * @author Ensuro
@@ -23,22 +23,22 @@ contract AAVEv3AssetManager is LiquidityThresholdAssetManager {
     _aToken = IERC20Metadata(aave_.getReserveData(address(asset_)).aTokenAddress);
   }
 
-  function connect() public override {
+  function connect() public virtual override {
     super.connect();
     _asset.approve(address(_aave), type(uint256).max); // infinite approval to the AAVE lending pool
   }
 
-  function _invest(uint256 amount) internal override {
+  function _invest(uint256 amount) internal virtual override {
     super._invest(amount);
     _aave.supply(address(_asset), amount, address(this), 0);
   }
 
-  function _deinvest(uint256 amount) internal override {
+  function _deinvest(uint256 amount) internal virtual override {
     super._deinvest(amount);
     _aave.withdraw(address(_asset), amount, address(this));
   }
 
-  function deinvestAll() external override returns (int256 earnings) {
+  function deinvestAll() external virtual override returns (int256 earnings) {
     DiamondStorage storage ds = diamondStorage();
     uint256 withdrawn = (_aToken.balanceOf(address(this)) != 0)
       ? _aave.withdraw(address(_asset), type(uint256).max, address(this))
@@ -50,7 +50,7 @@ contract AAVEv3AssetManager is LiquidityThresholdAssetManager {
     return earnings;
   }
 
-  function getInvestmentValue() public view override returns (uint256) {
+  function getInvestmentValue() public view virtual override returns (uint256) {
     return _aToken.balanceOf(address(this));
   }
 }

--- a/contracts/AAVEv3PlusVaultAssetManager.sol
+++ b/contracts/AAVEv3PlusVaultAssetManager.sol
@@ -28,7 +28,10 @@ contract AAVEv3PlusVaultAssetManager is AAVEv3AssetManager {
       address(vault_) != address(0),
       "AAVEv3PlusVaultAssetManager: vault cannot be zero address"
     );
-    require(address(asset_) != vault_.asset(), "ERC4626AssetManager: vault cannot be zero address");
+    require(
+      address(asset_) == vault_.asset(),
+      "AAVEv3PlusVaultAssetManager: vault must have the same asset"
+    );
     _vault = vault_;
   }
 

--- a/contracts/AAVEv3PlusVaultAssetManager.sol
+++ b/contracts/AAVEv3PlusVaultAssetManager.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {AAVEv3AssetManager} from "./AAVEv3AssetManager.sol";
+import {LiquidityThresholdAssetManager} from "@ensuro/core/contracts/LiquidityThresholdAssetManager.sol";
+import {IPool} from "./dependencies/aave-v3/IPool.sol";
+
+/**
+ * @title Asset Manager that deploys the funds into AAVEv3 but also, at request, can deploy the funds in a vault.
+ * @dev Using liquidity thresholds defined in {LiquidityThresholdAssetManager}, deploys the funds into AAVEv3.
+ *      By request of the administrator it can also deploy the funds in a vault. When deinvesting, it AAVEv3 funds
+ *      aren't enough for the required amount, it tries to withdraw from the vault.
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract AAVEv3PlusVaultAssetManager is AAVEv3AssetManager {
+  IERC4626 internal immutable _vault;
+
+  constructor(
+    IERC20Metadata asset_,
+    IPool aave_,
+    IERC4626 vault_
+  ) AAVEv3AssetManager(asset_, aave_) {
+    require(
+      address(vault_) != address(0),
+      "AAVEv3PlusVaultAssetManager: vault cannot be zero address"
+    );
+    require(address(asset_) != vault_.asset(), "ERC4626AssetManager: vault cannot be zero address");
+    _vault = vault_;
+  }
+
+  function _deinvest(uint256 amount) internal virtual override {
+    LiquidityThresholdAssetManager._deinvest(amount);
+    uint256 aaveAmount = Math.min(amount, _aToken.balanceOf(address(this)));
+    if (aaveAmount != 0) _aave.withdraw(address(_asset), aaveAmount, address(this));
+    if (amount - aaveAmount != 0)
+      _vault.withdraw(amount - aaveAmount, address(this), address(this));
+  }
+
+  function connect() public override {
+    super.connect();
+    _asset.approve(address(_vault), type(uint256).max); // infinite approval to the vault
+  }
+
+  function deinvestAll() external virtual override returns (int256 earnings) {
+    DiamondStorage storage ds = diamondStorage();
+    uint256 fromAAVE = (_aToken.balanceOf(address(this)) != 0)
+      ? _aave.withdraw(address(_asset), type(uint256).max, address(this))
+      : 0;
+    /**
+     * WARNING: this was implemented withdrawing as much as possible from the vault WITHOUT failing.
+     * This implementation might leave some assets (those that aren't withdrawable) in the vault and those will
+     * be reported as losses.
+     */
+    uint256 redeemable = _vault.maxRedeem(address(this));
+    uint256 fromVault = redeemable != 0
+      ? _vault.redeem(redeemable, address(this), address(this))
+      : 0;
+    earnings = int256(fromAAVE + fromVault) - int256(uint256(ds.lastInvestmentValue));
+    ds.lastInvestmentValue = 0;
+    emit MoneyDeinvested(fromAAVE + fromVault);
+    emit EarningsRecorded(earnings);
+    return earnings;
+  }
+
+  function getInvestmentValue() public view virtual override returns (uint256) {
+    return
+      _aToken.balanceOf(address(this)) + _vault.convertToAssets(_vault.balanceOf(address(this)));
+  }
+
+  /**
+   * @dev Transfers the given amount from AAVE to the vault
+   *
+   * @param amount The amount to transfer. If that amount isn't available in AAVE it reverts.
+   *               If amount = type(uint256).max it withdraws all the funds from AAVE.
+   */
+  function aaveToVault(uint256 amount) external {
+    uint256 withdrawn = _aave.withdraw(address(_asset), amount, address(this));
+    _vault.deposit(withdrawn, address(this));
+  }
+
+  /**
+   * @dev Transfers the given amount from the vault to AAVE
+   *
+   * @param amount The amount to transfer. If that amount isn't available in the vault it reverts.
+   *               If amount = type(uint256).max it withdraws all the funds withdrawable in the vault
+   */
+  function vaultToAave(uint256 amount) external {
+    uint256 withdrawn;
+    if (amount == type(uint256).max) {
+      withdrawn = _vault.redeem(_vault.maxRedeem(address(this)), address(this), address(this));
+    } else {
+      _vault.withdraw(amount, address(this), address(this));
+      withdrawn = amount;
+    }
+    _aave.supply(address(_asset), withdrawn, address(this), 0);
+  }
+}

--- a/contracts/mocks/TestVault.sol
+++ b/contracts/mocks/TestVault.sol
@@ -1,0 +1,79 @@
+//SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+
+contract TestVault is ERC4626 {
+  using SafeERC20 for IERC20Metadata;
+
+  uint256 internal _debt;
+
+  constructor(
+    string memory name_,
+    string memory symbol_,
+    IERC20Metadata asset_
+  ) ERC20(name_, symbol_) ERC4626(asset_) {}
+
+  /** @dev See {IERC4262-totalAssets}. */
+  function totalAssets() public view virtual override returns (uint256) {
+    return _balance() + _debt;
+  }
+
+  function _asset() internal view returns (IERC20Metadata) {
+    return IERC20Metadata(asset());
+  }
+
+  function _balance() internal view returns (uint256) {
+    return _asset().balanceOf(address(this));
+  }
+
+  /**
+   * @dev Withdraw/redeem common workflow.
+   */
+  function _withdraw(
+    address caller,
+    address receiver,
+    address owner,
+    uint256 assets,
+    uint256 shares
+  ) internal virtual override {
+    require(_balance() >= assets, "ERC4626CashFlowLender: Not enough balance to withdraw");
+    super._withdraw(caller, receiver, owner, assets, shares);
+  }
+
+  /** @dev See {IERC4626-maxWithdraw}. */
+  function maxWithdraw(address owner) public view virtual override returns (uint256) {
+    return Math.min(super.maxWithdraw(owner), _balance());
+  }
+
+  /** @dev See {IERC4626-maxRedeem}. */
+  function maxRedeem(address owner) public view virtual override returns (uint256) {
+    return Math.min(super.maxRedeem(owner), _convertToShares(_balance(), Math.Rounding.Down));
+  }
+
+  /**
+   * Two functions to simulate an iliquid vault that gives loans (without collateral, it's a mock Contract)
+   * and receives the repayment with interest, increasing the assets (and not the shares).
+   */
+  function lend(address borrower, uint256 amount) external {
+    _debt += amount;
+    _asset().safeTransfer(borrower, amount);
+  }
+
+  function repay(
+    address borrower,
+    uint256 amount,
+    uint256 interest
+  ) external {
+    _debt -= amount;
+    _asset().safeTransferFrom(borrower, address(this), amount + interest);
+  }
+
+  function debtDefault(uint256 amount) external {
+    _debt -= amount;
+  }
+}


### PR DESCRIPTION
New asset manager implementation that also supports deploying some funds into an ERC-4626 vault. The AM by default works the same way as the AAVEv3AM but it can receive requests (that would be sent via `forwardToAssetManager(...)`) to transfer some funds from AAVE to the AM or the other way around.

When deinvesting funds, it always deinvests first from AAVE and only deinvests from the vault when no more funds in AAVE.